### PR TITLE
Rename project name for lerobot integration

### DIFF
--- a/lerobot_robot_ur5e/pyproject.toml
+++ b/lerobot_robot_ur5e/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "lerobot-robot-ur5e"
+name = "lerobot_robot_ur5e"
 version = "0.1.0"
 description = "A lerobot plugin for the UR5e robot with a Robotiq gripper."
 requires-python = ">=3.11"


### PR DESCRIPTION
Currently, including the `lerobot_robot_ur5e` in an external project via `uv add "git+https://github.com/F-Fer/lerobot_ur5e_gello#subdirectory=lerobot_robot_ur5e"` fails at runtime because the distribution name is `lerobot-robot-ur5e` instead of `lerobot_robot_ur5e`.

LeRobot plugin system require underscores in the distribution name: https://github.com/huggingface/lerobot/blob/main/src/lerobot/utils/import_utils.py#L152

The proposed change fix the issue